### PR TITLE
Replace template literal libraries by patching require()

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,14 +2,32 @@
 
 Lightning fast server-side rendering with tagged template literals
 
+A tiny library that enables lightning fast server-side rendering with [hyperx](https://github.com/substack/hyperx)-like libraries such as `bel`, `yo-yo` and `choo/html`. It replaces the tag function of those libraries and just renders string without creating intermediate objects.
+
+## Installing
+
+```sh
+npm install pelo
+```
+
 ## Usage
 
-**TBD**
+`ssr.js`: Call `pelo.replace(moduleId)` before you require any view module, `bel` in this case.
 
 ```js
-const html = require('pelo')
+const pelo = require('pelo')
+pelo.replace('bel')
+const view = require('./view')
 
-function helloView(name) {
+const renderedString = view('pelo').toString()
+```
+
+`view.js`: You don't need to change your view files at all. You can use them for client-side rendering and server-side rendering.
+
+```js
+const html = require('bel')
+
+module.exports = function helloView(name) {
   return html`<p>Hello, ${name}</p>`
 }
 ```

--- a/app.js
+++ b/app.js
@@ -1,4 +1,7 @@
-module.exports = function (html) {
+module.exports = function () {
+  // Allow `bel` to be swapped in benchmarking
+  const html = require('bel')
+
   const greeting = 'Hello'
   const name = 'special characters, <, >, &'
   const drinks = [

--- a/benchmark.js
+++ b/benchmark.js
@@ -1,25 +1,28 @@
-const bel = require('bel')
-const stringify = require('.')
+const pelo = require('.')
 const createApp = require('./app')
 
+const warmup = 100
 const iteration = 10000
 
-const strApp = createApp(stringify)
-const belApp = createApp(bel)
-console.log('# stringify output')
-console.log(strApp.render().toString())
-console.log('# bel output')
-console.log(belApp.render().toString())
 console.log(`# benchmark ${iteration} iterations`)
 
-console.time('pelo')
-for (let i = 0; i < iteration; i++) {
-  strApp.render().toString()
+const belApp = createApp()
+for (let i = 0; i < warmup; i++) {
+  belApp.render().toString()
 }
-console.timeEnd('pelo')
-
 console.time('bel')
 for (let i = 0; i < iteration; i++) {
   belApp.render().toString()
 }
 console.timeEnd('bel')
+
+pelo.replace('bel')
+const peloApp = createApp()
+for (let i = 0; i < warmup; i++) {
+  peloApp.render().toString()
+}
+console.time('pelo')
+for (let i = 0; i < iteration; i++) {
+  peloApp.render().toString()
+}
+console.timeEnd('pelo')

--- a/client.js
+++ b/client.js
@@ -1,9 +1,8 @@
-const bel = require('bel')
 const nanomorph = require('nanomorph')
 
 const createApp = require('./app')
 
-const app = createApp(bel)
+const app = createApp()
 
 const root = document.getElementById('root')
 const tree = root.firstElementChild

--- a/compare.js
+++ b/compare.js
@@ -1,0 +1,11 @@
+const pelo = require('.')
+const createApp = require('./app')
+
+const belApp = createApp()
+console.log('# bel output')
+console.log(belApp.render().toString())
+
+pelo.replace('bel')
+const peloApp = createApp()
+console.log('# pelo output')
+console.log(peloApp.render().toString())

--- a/index.js
+++ b/index.js
@@ -1,3 +1,5 @@
+const Module = require('module')
+
 function handleValue (value) {
   if (Array.isArray(value)) {
     // Suppose that each item is a result of html``.
@@ -41,5 +43,17 @@ function stringify () {
   wrapper.__encoded = true
   return wrapper
 }
+
+function replace(moduleId) {
+  const originalRequire = Module.prototype.require
+  Module.prototype.require = function (id) {
+    if (id === moduleId) {
+      return stringify
+    } else {
+      return originalRequire.apply(this, arguments)
+    }
+  }
+}
+stringify.replace = replace
 
 module.exports = stringify

--- a/package.json
+++ b/package.json
@@ -3,16 +3,15 @@
   "version": "0.0.0",
   "description": "Lightning fast server-side rendering with tagged template literals",
   "main": "index.js",
-  "browser": "bel",
   "scripts": {
     "start": "npm run build && node server.js",
     "test": "node benchmark.js",
-    "build": "browserify client.js > bundle.js"
+    "build": "browserify client.js > bundle.js",
+    "compare": "node compare.js"
   },
-  "dependencies": {
-    "bel": "^4.6.0"
-  },
+  "dependencies": {},
   "devDependencies": {
+    "bel": "^4.6.0",
     "browserify": "^14.3.0",
     "nanomorph": "^4.0.4",
     "standard": "^10.0.2"

--- a/server.js
+++ b/server.js
@@ -1,10 +1,11 @@
 const http = require('http')
 const fs = require('fs')
 
+const pelo = require('.')
+pelo.replace('bel')
 const createApp = require('./app')
-const html = require('.')
 
-const app = createApp(html)
+const app = createApp()
 
 function layout (content) {
   return `


### PR DESCRIPTION
Provide `pelo.replace(moduleId)` to replace `hyperx`-like libraries such as `bel`, `yo-yo`, `choo/html` on server-side. In this way:

- Users don't need to change their view scripts at all.
- View files just work with [yo-yoify](https://github.com/shama/yo-yoify) out of the box. yo-yoify only works hardcoded modules such as `bel`, `yo-yo`, `choo` and `choo/html`. Because users' view files stay same, we don't need to make a pull request to `yo-yoify`.

Fixes #2 and #3