### PR TITLE
More robust attribute handling, closes #14

### DIFF
--- a/app.js
+++ b/app.js
@@ -49,6 +49,9 @@ module.exports = function () {
         ` : html`
           <p>All drinks are gone!</p>
         `}
+        <p>
+          attributes: <input type=text value=${''} disabled onclick="${() => alert('hello')}" ${{ title: '<Special " characters>' }} />
+        </p>
       </div>
     `
   }

--- a/index.js
+++ b/index.js
@@ -23,6 +23,10 @@ function replaceMapper (matched){
   return replaceMap[matched]
 }
 
+function escape (value) {
+  return value.toString().replace(replaceMapRE, replaceMapper)
+}
+
 function handleValue (value) {
   if (value === null || value === undefined || value === false) {
     return ''
@@ -38,7 +42,7 @@ function handleValue (value) {
   //     onclick=""
   const valueType = typeof value
   if (valueType === 'function') {
-    return '""'
+    return ''
   }
 
   if (valueType === 'object' && value.constructor.name !== 'String') {
@@ -49,14 +53,20 @@ function handleValue (value) {
     return value
   }
 
-  return value.toString().replace(replaceMapRE, replaceMapper)
+  return escape(value)
 }
 
 function stringify () {
   var pieces = arguments[0]
   var output = ''
   for (var i = 0; i < pieces.length - 1; i++) {
-    output += pieces[i] + handleValue(arguments[i + 1])
+    var piece = pieces[i]
+    var value = handleValue(arguments[i + 1])
+    if (piece[piece.length - 1] === '=') {
+      output += piece + '"' + value + '"'
+    } else {
+      output += piece + value
+    }
   }
   output += pieces[i]
   output = output
@@ -75,9 +85,9 @@ function objToString (obj) {
   var values = ''
   const keys = Object.keys(obj)
   for (var i = 0; i < keys.length - 1; i++) {
-    values += keys[i] + '="' + (obj[keys[i]] || '') + '" '
+    values += keys[i] + '="' + escape(obj[keys[i]] || '') + '" '
   }
-  return values + keys[i] + '="' + (obj[keys[i]] || '') + '"'
+  return values + keys[i] + '="' + escape(obj[keys[i]] || '') + '"'
 }
 
 function replace (moduleId) {


### PR DESCRIPTION
This patch addresses cases where:

 - An attribute value is the empty string and quotes are not used
 as in `value=${xyz}`
 - An attribute value is a function and quotes _are_ used
 as in `onclick="${onclick}"` (this works in hyperx)
 - An object attribute value contains special characters as in
 `${{ value: 'with"quotes' }}` (possible xss vector)

To support the first two cases, it checks whether the character right
before an interpolated value is `=`. If so, it adds quotes.

The benchmarks take a significant hit, I guess because of this
additional check. They are up from 290ish ms to 310ish ms on my
machine for 10k renders. Something like an 8% slowdown. I think the
correctness is worth it though, especially doing `value=${xyz}` is quite
common.